### PR TITLE
Display name builder now returns a Widget

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -65,7 +65,7 @@ class _MyHomePageState extends State<MyHomePage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Gantt chart demo'),
+        title: const Text('Gantt chart demo'),
         actions: [
           IconButton(
             onPressed: onZoomIn,
@@ -86,7 +86,7 @@ class _MyHomePageState extends State<MyHomePage> {
           children: [
             SwitchListTile.adaptive(
               value: showDaysRow,
-              title: Text('Show Days Row ?'),
+              title: const Text('Show Days Row ?'),
               onChanged: (newVal) {
                 setState(() {
                   showDaysRow = newVal;
@@ -95,7 +95,7 @@ class _MyHomePageState extends State<MyHomePage> {
             ),
             SwitchListTile.adaptive(
               value: showStickyArea,
-              title: Text('Show Sticky Area ?'),
+              title: const Text('Show Sticky Area ?'),
               onChanged: (newVal) {
                 setState(() {
                   showStickyArea = newVal;

--- a/lib/src/event.dart
+++ b/lib/src/event.dart
@@ -47,7 +47,7 @@ abstract class GanttEventBase {
   Object? get extra;
   String? get displayName;
   Color? get suggestedColor;
-  String Function(BuildContext context)? get displayNameBuilder;
+  Widget Function(BuildContext context)? get displayNameBuilder;
 
   DateTime getStartDateInclusive(
     BuildContext context,
@@ -62,9 +62,6 @@ abstract class GanttEventBase {
     Set<WeekDay> weekends,
     IsExtraHolidayFunc isExtraHolidayFunc,
   );
-
-  String getDisplayName(BuildContext context) =>
-      displayName ?? displayNameBuilder?.call(context) ?? '';
 }
 
 class GanttAbsoluteEvent extends GanttEventBase {
@@ -73,7 +70,7 @@ class GanttAbsoluteEvent extends GanttEventBase {
   @override
   final String? displayName;
   @override
-  final String Function(BuildContext context)? displayNameBuilder;
+  final Widget Function(BuildContext context)? displayNameBuilder;
   @override
   final Object? extra;
 
@@ -118,7 +115,7 @@ class GanttRelativeEvent extends GanttEventBase {
   @override
   final String? displayName;
   @override
-  final String Function(BuildContext context)? displayNameBuilder;
+  final Widget Function(BuildContext context)? displayNameBuilder;
 
   @override
   final Color? suggestedColor;

--- a/lib/src/event.dart
+++ b/lib/src/event.dart
@@ -56,7 +56,7 @@ abstract class GanttEventBase {
     IsExtraHolidayFunc isExtraHolidayFunc,
   );
 
-  DateTime getEndDateExeclusive(
+  DateTime getEndDateExclusive(
     BuildContext context,
     DateTime calculatedStartDate,
     Set<WeekDay> weekends,
@@ -86,7 +86,7 @@ class GanttAbsoluteEvent extends GanttEventBase {
   });
 
   @override
-  DateTime getEndDateExeclusive(
+  DateTime getEndDateExclusive(
     BuildContext context,
     DateTime calculatedStartDate,
     Set<WeekDay> weekends,
@@ -146,7 +146,7 @@ class GanttRelativeEvent extends GanttEventBase {
       );
 
   @override
-  DateTime getEndDateExeclusive(
+  DateTime getEndDateExclusive(
     BuildContext context,
     DateTime calculatedStartDate,
     Set<WeekDay> weekends,

--- a/lib/src/gantt_view.dart
+++ b/lib/src/gantt_view.dart
@@ -226,9 +226,9 @@ class GanttChartViewState extends State<GanttChartView> {
                             ),
                           ),
                           child: Center(
-                            child: Text(
-                              event.getDisplayName(context),
-                            ),
+                            child: event.displayNameBuilder != null
+                                ? event.displayNameBuilder!.call(context)
+                                : Text(event.displayName ?? ""),
                           ),
                         ),
                   );

--- a/lib/src/gantt_view.dart
+++ b/lib/src/gantt_view.dart
@@ -298,7 +298,7 @@ class GanttChartViewState extends State<GanttChartView> {
                             weekEnds,
                             isHolidayCached,
                           );
-                          final actEndDate = e.getEndDateExeclusive(
+                          final actEndDate = e.getEndDateExclusive(
                             context,
                             actStartDate,
                             weekEnds,


### PR DESCRIPTION
Hi,

in this PR I've changed the return type of `displayNameBuilder` from `String` to `Widget` for improved flexibility. Now it's possible to fully customize how names are shown, e.g.

```dart
      GanttAbsoluteEvent(
        displayNameBuilder: (_) => Text(
          'My Event Title',
          style: Theme.of(context).textTheme.bodyText2?.copyWith(color: Colors.white),
        ),
        // ...
      );
