### PR TITLE
Added parameter to customize weekDay decoration

### DIFF
--- a/lib/src/gantt_default_week_header.dart
+++ b/lib/src/gantt_default_week_header.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
 
 class GanttChartDefaultWeekHeader extends StatelessWidget {
+  final Decoration? decoration;
+
   const GanttChartDefaultWeekHeader({
     Key? key,
     required this.weekDate,
+    this.decoration,
   }) : super(key: key);
   final DateTime weekDate;
 
@@ -12,13 +15,14 @@ class GanttChartDefaultWeekHeader extends StatelessWidget {
     final bgColor = Colors.blue.shade900;
     return Container(
       padding: const EdgeInsetsDirectional.only(start: 8, top: 1, bottom: 1),
-      decoration: BoxDecoration(
-        color: bgColor,
-        border: const BorderDirectional(
-          start: BorderSide(),
-          bottom: BorderSide(),
-        ),
-      ),
+      decoration: decoration ??
+          BoxDecoration(
+            color: bgColor,
+            border: const BorderDirectional(
+              start: BorderSide(),
+              bottom: BorderSide(),
+            ),
+          ),
       child: Center(
         child: LayoutBuilder(builder: (context, constraints) {
           String txt;

--- a/lib/src/gantt_view.dart
+++ b/lib/src/gantt_view.dart
@@ -37,6 +37,7 @@ class GanttChartView extends StatefulWidget {
     this.weekEnds = const {WeekDay.friday, WeekDay.saturday},
     this.dayHeaderBuilder,
     this.weekHeaderBuilder,
+    this.weekHeaderDecoration,
     this.isExtraHoliday,
     this.eventRowPerWeekBuilder,
     this.startOfTheWeek = WeekDay.sunday,
@@ -80,6 +81,9 @@ class GanttChartView extends StatefulWidget {
   /// [weekDate] is the start of the week, which will always be a [startOfTheWeek]
   final Widget Function(BuildContext context, DateTime weekDate)?
       weekHeaderBuilder;
+
+  /// the cell decoration of the week header when using the default builder
+  final Decoration? weekHeaderDecoration;
 
   /// Show sticky row headers on the left
   final bool showStickyArea;
@@ -265,6 +269,7 @@ class GanttChartViewState extends State<GanttChartView> {
                             widget.weekHeaderBuilder?.call(context, weekDate) ??
                                 GanttChartDefaultWeekHeader(
                                   weekDate: weekDate,
+                                  decoration: widget.weekHeaderDecoration,
                                 ),
                       ),
                       if (widget.showDays)


### PR DESCRIPTION
Hi,

I added a new parameter `weekHeaderDecoration` to make the view more customizable, e.g.

```dart
        weekHeaderDecoration: BoxDecoration(
          color: primaryColor,
          border: const BorderDirectional(
            end: BorderSide(color: Colors.white),
          ),
        ),
```

would produce

![Screenshot from 2022-07-28 11-30-20](https://user-images.githubusercontent.com/4000539/181472584-d9fc5c4b-ac68-45f2-b60b-a32800ba496b.png)

I know there's a `weekHeaderBuilder` already, but I think that's too much effort to override that altogether, some users might want to "use the default with a little help".
